### PR TITLE
Auto set resources

### DIFF
--- a/src/DealroadshowK8SBundle.php
+++ b/src/DealroadshowK8SBundle.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Dealroadshow\Bundle\K8SBundle;
 
 use Dealroadshow\Bundle\K8SBundle\DependencyInjection\Compiler\AppsPass;
+use Dealroadshow\Bundle\K8SBundle\DependencyInjection\Compiler\AutoSetReplicasPass;
+use Dealroadshow\Bundle\K8SBundle\DependencyInjection\Compiler\AutoSetResourcesPass;
 use Dealroadshow\Bundle\K8SBundle\DependencyInjection\Compiler\EnabledManifestsPass;
 use Dealroadshow\Bundle\K8SBundle\DependencyInjection\Compiler\ManifestGeneratorContextsPass;
 use Dealroadshow\Bundle\K8SBundle\DependencyInjection\Compiler\ManifestsPass;
@@ -30,10 +32,12 @@ class DealroadshowK8SBundle extends Bundle
             ->addCompilerPass(pass: new EnabledManifestsPass(), priority: -8)
             ->addCompilerPass(pass: new SetAppConfigPass(), type: PassConfig::TYPE_OPTIMIZE, priority: -8)
             ->addCompilerPass(pass: new ManifestsPass(), type: PassConfig::TYPE_OPTIMIZE, priority: -16)
-            ->addCompilerPass(new ManifestGeneratorContextsPass())
-            ->addCompilerPass(new MiddlewarePass())
-            ->addCompilerPass(new ResourceMakersPass())
-            ->addCompilerPass(new RemoveAutowiredAppsPass(), PassConfig::TYPE_REMOVE)
+            ->addCompilerPass(pass: new ManifestGeneratorContextsPass())
+            ->addCompilerPass(pass: new MiddlewarePass())
+            ->addCompilerPass(pass: new ResourceMakersPass())
+            ->addCompilerPass(pass: new RemoveAutowiredAppsPass(), type: PassConfig::TYPE_REMOVE)
+            ->addCompilerPass(pass: new AutoSetReplicasPass(), priority: -32)
+            ->addCompilerPass(pass: new AutoSetResourcesPass(), priority: -32)
         ;
     }
 

--- a/src/DependencyInjection/Compiler/AutoSetReplicasPass.php
+++ b/src/DependencyInjection/Compiler/AutoSetReplicasPass.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dealroadshow\Bundle\K8SBundle\DependencyInjection\Compiler;
+
+use Dealroadshow\Bundle\K8SBundle\EventListener\AutoSetReplicasSubscriber;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class AutoSetReplicasPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $autoSetReplicas = $container->getParameter('dealroadshow_k8s.auto_set_replicas');
+        if (!$autoSetReplicas) {
+            $container->removeDefinition(AutoSetReplicasSubscriber::class);
+        }
+    }
+}

--- a/src/DependencyInjection/Compiler/AutoSetResourcesPass.php
+++ b/src/DependencyInjection/Compiler/AutoSetResourcesPass.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dealroadshow\Bundle\K8SBundle\DependencyInjection\Compiler;
+
+use Dealroadshow\Bundle\K8SBundle\EventListener\AutoSetResourcesSubscriber;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class AutoSetResourcesPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $autoSetResources = $container->getParameter('dealroadshow_k8s.auto_set_resources');
+        if (!$autoSetResources) {
+            $container->removeDefinition(AutoSetResourcesSubscriber::class);
+        }
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -131,8 +131,6 @@ readonly class Configuration implements ConfigurationInterface
 
     private function validResourcesNodeValue(array $nodeValue): array
     {
-        $config = ['resources' => $nodeValue];
-
-        return $this->processor->processConfiguration($this->resourcesConfiguration, [$config])['resources'];
+        return $this->processor->processConfiguration($this->resourcesConfiguration, [$nodeValue]);
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -4,14 +4,25 @@ declare(strict_types=1);
 
 namespace Dealroadshow\Bundle\K8SBundle\DependencyInjection;
 
+use Dealroadshow\Bundle\K8SBundle\DependencyInjection\ContainerResources\ContainerResourcesConfiguration;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
 
-class Configuration implements ConfigurationInterface
+readonly class Configuration implements ConfigurationInterface
 {
+    private ContainerResourcesConfiguration $resourcesConfiguration;
+    private Processor $processor;
+
+    public function __construct()
+    {
+        $this->resourcesConfiguration = new ContainerResourcesConfiguration();
+        $this->processor = new Processor();
+    }
+
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('dealroadshow_k8s');
@@ -19,10 +30,16 @@ class Configuration implements ConfigurationInterface
 
         $root
             ->children()
-                ->append(self::appsNode())
+                ->append($this->appsNode())
                 ->scalarNode('code_dir')->defaultNull()->end()
                 ->scalarNode('namespace_prefix')->defaultValue('App\\K8S\\')->end()
                 ->scalarNode('manifests_dir')->defaultNull()->end()
+                ->booleanNode('auto_set_resources')
+                    ->defaultFalse()
+                ->end()
+                ->booleanNode('auto_set_replicas')
+                    ->defaultFalse()
+                ->end()
                 ->arrayNode('filterManifests')
                     ->addDefaultsIfNotSet()
                     ->children()
@@ -44,7 +61,7 @@ class Configuration implements ConfigurationInterface
         return $treeBuilder;
     }
 
-    public static function appsNode(): ArrayNodeDefinition
+    public function appsNode(): ArrayNodeDefinition
     {
         $treeBuilder = new TreeBuilder('apps');
         $node = $treeBuilder->getRootNode();
@@ -60,7 +77,37 @@ class Configuration implements ConfigurationInterface
                         ->cannotBeOverwritten()
                         ->beforeNormalization()
                             ->ifString()
-                            ->then(\Closure::fromCallable([static::class, 'validClassName']))
+                            ->then(static::validClassName(...))
+                        ->end()
+                    ->end()
+                    ->arrayNode('manifests')
+                        ->useAttributeAsKey('name')
+                        ->arrayPrototype()
+                            ->ignoreExtraKeys(false)
+                            ->children()
+                                ->booleanNode('virtual')
+                                    ->defaultFalse()
+                                ->end()
+                                ->integerNode('replicas')
+                                    ->cannotBeEmpty()
+                                ->end()
+                                ->arrayNode('resources')
+                                    ->children()
+                                        ->variableNode('requests')
+                                            ->validate()
+                                                ->ifArray()
+                                                ->then($this->validResourcesNodeValue(...))
+                                            ->end()
+                                        ->end()
+                                        ->variableNode('limits')
+                                            ->validate()
+                                                ->ifArray()
+                                                ->then($this->validResourcesNodeValue(...))
+                                            ->end()
+                                        ->end()
+                                    ->end()
+                                ->end()
+                            ->end()
                         ->end()
                     ->end()
                 ->end()
@@ -69,9 +116,6 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    /**
-     * @throws \ReflectionException
-     */
     private static function validClassName(string $class): string
     {
         if (!class_exists($class)) {
@@ -84,5 +128,12 @@ class Configuration implements ConfigurationInterface
         }
 
         return $class;
+    }
+
+    private function validResourcesNodeValue(array $nodeValue): array
+    {
+        $config = ['resources' => $nodeValue];
+
+        return $this->processor->processConfiguration($this->resourcesConfiguration, [$config])['resources'];
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -89,7 +89,6 @@ readonly class Configuration implements ConfigurationInterface
                                     ->defaultFalse()
                                 ->end()
                                 ->integerNode('replicas')
-                                    ->cannotBeEmpty()
                                 ->end()
                                 ->arrayNode('resources')
                                     ->children()

--- a/src/DependencyInjection/ContainerResources/ContainerResourcesConfiguration.php
+++ b/src/DependencyInjection/ContainerResources/ContainerResourcesConfiguration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Dealroadshow\Bundle\K8SBundle\DependencyInjection\ContainerResources;
 
 use Dealroadshow\K8S\Framework\Core\Container\Resources\CPU;
@@ -36,7 +38,7 @@ readonly class ContainerResourcesConfiguration implements ConfigurationInterface
             ->cannotBeEmpty()
             ->beforeNormalization()
                 ->ifString()
-                ->then(function(string $cpu) {
+                ->then(function (string $cpu) {
                     try {
                         CPU::fromString($cpu);
                     } catch (\InvalidArgumentException $e) {
@@ -60,7 +62,7 @@ readonly class ContainerResourcesConfiguration implements ConfigurationInterface
             ->cannotBeEmpty()
             ->beforeNormalization()
                 ->ifString()
-                ->then(function(string $memory) {
+                ->then(function (string $memory) {
                     try {
                         Memory::fromString($memory);
                     } catch (\InvalidArgumentException $e) {

--- a/src/DependencyInjection/ContainerResources/ContainerResourcesConfiguration.php
+++ b/src/DependencyInjection/ContainerResources/ContainerResourcesConfiguration.php
@@ -42,6 +42,8 @@ readonly class ContainerResourcesConfiguration implements ConfigurationInterface
                     } catch (\InvalidArgumentException $e) {
                         throw new InvalidConfigurationException($e->getMessage());
                     }
+
+                    return $cpu;
                 })
             ->end();
 
@@ -64,6 +66,8 @@ readonly class ContainerResourcesConfiguration implements ConfigurationInterface
                     } catch (\InvalidArgumentException $e) {
                         throw new InvalidConfigurationException($e->getMessage());
                     }
+
+                    return $memory;
                 })
             ->end();
 

--- a/src/DependencyInjection/ContainerResources/ContainerResourcesConfiguration.php
+++ b/src/DependencyInjection/ContainerResources/ContainerResourcesConfiguration.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Dealroadshow\Bundle\K8SBundle\DependencyInjection\ContainerResources;
+
+use Dealroadshow\K8S\Framework\Core\Container\Resources\CPU;
+use Dealroadshow\K8S\Framework\Core\Container\Resources\Memory;
+use Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+readonly class ContainerResourcesConfiguration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('resources');
+        $root = $treeBuilder->getRootNode();
+
+        $root
+            ->children()
+                ->append($this->cpuNode())
+                ->append($this->memoryNode('memory'))
+                ->append($this->memoryNode('storage'))
+            ->end();
+
+        return $treeBuilder;
+    }
+
+    private function cpuNode(): ScalarNodeDefinition
+    {
+        $treeBuilder = new TreeBuilder('cpu', 'scalar');
+
+        /** @var ScalarNodeDefinition $root */
+        $root = $treeBuilder->getRootNode();
+        $root
+            ->cannotBeEmpty()
+            ->beforeNormalization()
+                ->ifString()
+                ->then(function(string $cpu) {
+                    try {
+                        CPU::fromString($cpu);
+                    } catch (\InvalidArgumentException $e) {
+                        throw new InvalidConfigurationException($e->getMessage());
+                    }
+                })
+            ->end();
+
+        return $root;
+    }
+
+    private function memoryNode(string $name): ScalarNodeDefinition
+    {
+        $treeBuilder = new TreeBuilder($name, 'scalar');
+
+        /** @var ScalarNodeDefinition $root */
+        $root = $treeBuilder->getRootNode();
+        $root
+            ->cannotBeEmpty()
+            ->beforeNormalization()
+                ->ifString()
+                ->then(function(string $memory) {
+                    try {
+                        Memory::fromString($memory);
+                    } catch (\InvalidArgumentException $e) {
+                        throw new InvalidConfigurationException($e->getMessage());
+                    }
+                })
+            ->end();
+
+        return $root;
+    }
+}

--- a/src/DependencyInjection/DealroadshowK8SExtension.php
+++ b/src/DependencyInjection/DealroadshowK8SExtension.php
@@ -74,7 +74,8 @@ class DealroadshowK8SExtension extends Extension
             ->setupNamespacePrefix($config['namespace_prefix'], $container)
         ;
 
-        $container->setParameter('dealroadshow_k8s.config.apps', $config['apps']);
+        $container->setParameter('dealroadshow_k8s.auto_set_resources', $config['auto_set_resources']);
+        $container->setParameter('dealroadshow_k8s.auto_set_replicas', $config['auto_set_replicas']);
     }
 
     public function getAlias(): string

--- a/src/DependencyInjection/DealroadshowK8SExtension.php
+++ b/src/DependencyInjection/DealroadshowK8SExtension.php
@@ -74,6 +74,7 @@ class DealroadshowK8SExtension extends Extension
             ->setupNamespacePrefix($config['namespace_prefix'], $container)
         ;
 
+        $container->setParameter('dealroadshow_k8s.config.apps', $config['apps']);
         $container->setParameter('dealroadshow_k8s.auto_set_resources', $config['auto_set_resources']);
         $container->setParameter('dealroadshow_k8s.auto_set_replicas', $config['auto_set_replicas']);
     }

--- a/src/EventListener/AutoSetReplicasSubscriber.php
+++ b/src/EventListener/AutoSetReplicasSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dealroadshow\Bundle\K8SBundle\EventListener;
+
+use Dealroadshow\Bundle\K8SBundle\Util\PropertyAccessUtil;
+use Dealroadshow\K8S\Framework\App\AppInterface;
+use Dealroadshow\K8S\Framework\Core\Deployment\DeploymentInterface;
+use Dealroadshow\K8S\Framework\Core\StatefulSet\StatefulSetInterface;
+use Dealroadshow\K8S\Framework\Event\ManifestMethodEvent;
+use Dealroadshow\K8S\Framework\Event\ProxyableMethodEventInterface;
+
+class AutoSetReplicasSubscriber extends AbstractMethodSubscriber
+{
+    protected function supports(ProxyableMethodEventInterface $event): bool
+    {
+        $manifest = $event->proxyable();
+        $supportedWorkload = $manifest instanceof DeploymentInterface || $manifest instanceof StatefulSetInterface;
+
+        return $supportedWorkload && 'replicas' === $event->methodName();
+    }
+
+    protected function beforeMethod(ProxyableMethodEventInterface $event): void
+    {
+        /** @var DeploymentInterface|StatefulSetInterface $manifest */
+        $manifest = $event->proxyable();
+        /** @var AppInterface $app */
+        $app = PropertyAccessUtil::getPropertyValue($manifest, 'app');
+        $replicas = $app->manifestConfig($manifest::shortName())['replicas'] ?? null;
+        if ($replicas) {
+            $event->setReturnValue($replicas);
+        }
+    }
+
+    protected static function eventNames(): iterable
+    {
+        yield ManifestMethodEvent::NAME;
+    }
+}

--- a/src/EventListener/AutoSetResourcesSubscriber.php
+++ b/src/EventListener/AutoSetResourcesSubscriber.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dealroadshow\Bundle\K8SBundle\EventListener;
+
+use Dealroadshow\Bundle\K8SBundle\Util\PropertyAccessUtil;
+use Dealroadshow\K8S\Framework\App\AppInterface;
+use Dealroadshow\K8S\Framework\Core\Container\ContainerInterface;
+use Dealroadshow\K8S\Framework\Core\Container\Resources\ContainerResourcesInterface;
+use Dealroadshow\K8S\Framework\Core\Container\Resources\CPU;
+use Dealroadshow\K8S\Framework\Core\Container\Resources\Memory;
+use Dealroadshow\K8S\Framework\Core\Deployment\DeploymentInterface;
+use Dealroadshow\K8S\Framework\Core\Job\JobInterface;
+use Dealroadshow\K8S\Framework\Core\StatefulSet\StatefulSetInterface;
+use Dealroadshow\K8S\Framework\Event\ContainerMethodEvent;
+use Dealroadshow\K8S\Framework\Event\ManifestMethodEvent;
+use Dealroadshow\K8S\Framework\Event\ProxyableMethodEventInterface;
+
+class AutoSetResourcesSubscriber extends AbstractMethodSubscriber
+{
+    protected function supports(ProxyableMethodEventInterface $event): bool
+    {
+        $manifest = $event->proxyable();
+        $supportedWorkload = $manifest instanceof DeploymentInterface
+            || $manifest instanceof JobInterface
+            || $manifest instanceof StatefulSetInterface;
+
+        return $supportedWorkload && $manifest instanceof ContainerInterface && 'resources' === $event->methodName();
+    }
+
+    protected function beforeMethod(ProxyableMethodEventInterface $event): void
+    {
+        /** @var DeploymentInterface|StatefulSetInterface $manifest */
+        $manifest = $event->proxyable();
+        /** @var AppInterface $app */
+        $app = PropertyAccessUtil::getPropertyValue($manifest, 'app');
+        $config = $app->manifestConfig($manifest::shortName())['resources'] ?? [];
+
+        /** @var ContainerResourcesInterface $resources */
+        $resources = $event->methodParams()['resources'];
+
+        $cpuRequests = $config['requests']['cpu'] ?? null;
+        $cpuLimits = $config['limits']['cpu'] ?? null;
+        if ($cpuRequests) {
+            $resources->requestCPU(CPU::fromString($cpuRequests));
+        }
+        if ($cpuLimits) {
+            $resources->limitCPU(CPU::fromString($cpuLimits));
+        }
+
+        $memoryRequests = $config['requests']['memory'] ?? null;
+        $memoryLimits = $config['limits']['memory'] ?? null;
+        if ($memoryRequests) {
+            $resources->requestMemory(Memory::fromString($memoryRequests));
+        }
+        if ($memoryLimits) {
+            $resources->limitMemory(Memory::fromString($memoryLimits));
+        }
+
+        $storageRequests = $config['requests']['storage'] ?? null;
+        $storageLimits = $config['limits']['storage'] ?? null;
+        if ($storageRequests) {
+            $resources->requestStorage(Memory::fromString($storageRequests));
+        }
+        if ($storageLimits) {
+            $resources->limitStorage(Memory::fromString($storageLimits));
+        }
+
+        if (!empty($resources['requests']) || !empty($resources['limits'])) {
+            // We don't want ambiguous behavior, so only one way of specifying resources should be used:
+            // if resources are automatically set from config, they should not be set by method
+            $event->setReturnValue(null); // This is done to prevent method body
+        }
+    }
+
+    protected static function eventNames(): iterable
+    {
+        yield ManifestMethodEvent::NAME;
+        yield ContainerMethodEvent::NAME;
+    }
+}

--- a/src/EventListener/AutoSetResourcesSubscriber.php
+++ b/src/EventListener/AutoSetResourcesSubscriber.php
@@ -67,7 +67,7 @@ class AutoSetResourcesSubscriber extends AbstractMethodSubscriber
             $resources->limitStorage(Memory::fromString($storageLimits));
         }
 
-        if (!empty($resources['requests']) || !empty($resources['limits'])) {
+        if (!empty($config['requests']) || !empty($config['limits'])) {
             // We don't want ambiguous behavior, so only one way of specifying resources should be used:
             // if resources are automatically set from config, they should not be set by method
             $event->setReturnValue(null); // This is done to prevent method body

--- a/src/Resources/config/dealroadshow_k8s.yaml
+++ b/src/Resources/config/dealroadshow_k8s.yaml
@@ -41,6 +41,8 @@ services:
     Dealroadshow\Bundle\K8SBundle\EventListener\BeforeMethodSubscriber: ~
     Dealroadshow\Bundle\K8SBundle\EventListener\ReplicasMethodSubscriber: ~
     Dealroadshow\Bundle\K8SBundle\EventListener\ResourcesMethodSubscriber: ~
+    Dealroadshow\Bundle\K8SBundle\EventListener\AutoSetReplicasSubscriber: ~
+    Dealroadshow\Bundle\K8SBundle\EventListener\AutoSetResourcesSubscriber: ~
     Dealroadshow\K8S\Framework\Renderer\FilteringService: ~
     Dealroadshow\K8S\Framework\Util\ManifestReferenceUtil: ~
     Dealroadshow\K8S\Framework\Proxy\EventDispatcherBridgeInterceptor: ~


### PR DESCRIPTION
This PR adds new feature, called 'Resources automatic setting', which allows to set resources requests / limits for workloads from config without writing `resources()` method in manifest class.