### PR TITLE
Enabled for container parameter attribute

### DIFF
--- a/src/DependencyInjection/Compiler/AppsPass.php
+++ b/src/DependencyInjection/Compiler/AppsPass.php
@@ -135,7 +135,7 @@ class AppsPass implements CompilerPassInterface
             if (!$this->enabledForCurrentEnv($class, $container->getParameter('kernel.environment'))) {
                 continue;
             }
-            if (!$this->enabledForEnvVar($class)) {
+            if (!$this->enabledForContainerParameter($class, $container)) {
                 continue;
             }
 

--- a/src/DependencyInjection/Compiler/EnabledManifestsPass.php
+++ b/src/DependencyInjection/Compiler/EnabledManifestsPass.php
@@ -22,7 +22,7 @@ class EnabledManifestsPass implements CompilerPassInterface
         foreach ($ids as $id => $tags) {
             $definition = $container->getDefinition($id);
             $class = new \ReflectionClass($definition->getClass());
-            if (!$this->enabledForCurrentEnv($class, $env) || !$this->enabledForEnvVar($class)) {
+            if (!$this->enabledForCurrentEnv($class, $env) || !$this->enabledForContainerParameter($class, $container)) {
                 $container->removeDefinition($id);
             }
         }

--- a/src/DependencyInjection/Compiler/Traits/CheckAttributesTrait.php
+++ b/src/DependencyInjection/Compiler/Traits/CheckAttributesTrait.php
@@ -47,7 +47,7 @@ trait CheckAttributesTrait
                 )
             );
         }
-        $parameter = $container->resolveEnvPlaceholders($container->getParameter($attribute->parameter));
+        $parameter = $container->resolveEnvPlaceholders($container->getParameter($attribute->parameter), true);
         if (!is_bool($parameter)) {
             throw new \RuntimeException(
                 sprintf(

--- a/src/DependencyInjection/Compiler/Traits/CheckAttributesTrait.php
+++ b/src/DependencyInjection/Compiler/Traits/CheckAttributesTrait.php
@@ -47,7 +47,7 @@ trait CheckAttributesTrait
                 )
             );
         }
-        $parameter = $container->getParameter($attribute->parameter);
+        $parameter = $container->resolveEnvPlaceholders($container->getParameter($attribute->parameter));
         if (!is_bool($parameter)) {
             throw new \RuntimeException(
                 sprintf(

--- a/src/EnvManagement/Attribute/EnabledForContainerParameter.php
+++ b/src/EnvManagement/Attribute/EnabledForContainerParameter.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Dealroadshow\Bundle\K8SBundle\EnvManagement\Attribute;
 
 #[\Attribute(\Attribute::TARGET_CLASS)]
-class DisabledForEnvVar
+readonly class EnabledForContainerParameter
 {
-    public function __construct(public readonly string $envVarName)
+    public function __construct(public string $parameter)
     {
     }
 }


### PR DESCRIPTION
This PR removes attribute `DisabledForEnvVar`, which did not work well with Symfony DI cache, and replaces it with `EnabledForContainerParameter` attribute. 