### PR TITLE
feat: ManifestName util

### DIFF
--- a/src/Util/ManifestName.php
+++ b/src/Util/ManifestName.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dealroadshow\Bundle\K8SBundle\Util;
+
+use Dealroadshow\K8S\Framework\Core\DynamicNameAwareInterface;
+use Dealroadshow\K8S\Framework\Core\ManifestInterface;
+
+final readonly class ManifestName
+{
+    public static function get(ManifestInterface $manifest): string
+    {
+        return $manifest instanceof DynamicNameAwareInterface
+            ? $manifest->name()
+            : $manifest::shortName();
+    }
+}


### PR DESCRIPTION
Adds `ManifestName` util in order to address the issue with repetitive code to get manifest name depending on whether it's dynamic or static