### PR TITLE
fix: dummy localization strategy

### DIFF
--- a/src/App/Integration/DummyLocalizationStrategy.php
+++ b/src/App/Integration/DummyLocalizationStrategy.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dealroadshow\Bundle\K8SBundle\App\Integration;
+
+use Dealroadshow\K8S\Framework\App\Integration\Localization\LocalizationStrategyInterface;
+
+class DummyLocalizationStrategy implements LocalizationStrategyInterface
+{
+    public function localize(string $dependentAppAlias, array $dependencies): mixed
+    {
+        throw new \RuntimeException(sprintf('You must implement "%s" in your manifests application or to not use app configuration localization functionality.', LocalizationStrategyInterface::class));
+    }
+}

--- a/src/Resources/config/dealroadshow_k8s.yaml
+++ b/src/Resources/config/dealroadshow_k8s.yaml
@@ -112,6 +112,7 @@ services:
 
     Dealroadshow\K8S\Framework\Renderer\RendererInterface: '@Dealroadshow\K8S\Framework\Renderer\YamlRenderer'
 
+    Dealroadshow\Bundle\K8SBundle\App\Integration\DummyLocalizationStrategy: ~
     Dealroadshow\K8S\Framework\App\Integration\Localization\LocalizationStrategyInterface: ~
 
     Dealroadshow\K8S\Framework\App\Integration\Localization\ExternalConfigurationLocalizer:


### PR DESCRIPTION
Adds `DummyLocalizationStrategy` in order for applications that use this bundle not to be required to implement `LocalizationStrategyInterface` to have a valid compiled Symfony DI container