### PR TITLE
fix: helpers as non-shared DI services

### DIFF
--- a/src/Resources/config/dealroadshow_k8s.yaml
+++ b/src/Resources/config/dealroadshow_k8s.yaml
@@ -17,8 +17,14 @@ services:
     Dealroadshow\K8S\Framework\Dumper\AppDumper: ~
     Dealroadshow\K8S\Framework\Renderer\YamlRenderer: ~
     Dealroadshow\K8S\Framework\Renderer\JsonRenderer: ~
-    Dealroadshow\K8S\Framework\Helper\Metadata\MetadataHelper: ~
-    Dealroadshow\K8S\Framework\Helper\Names\DefaultNamesHelper: ~
+    Dealroadshow\K8S\Framework\Helper\Metadata\MetadataHelper:
+        shared: false
+        autowire: true
+        autoconfigure: true
+    Dealroadshow\K8S\Framework\Helper\Names\DefaultNamesHelper:
+        shared: false
+        autowire: true
+        autoconfigure: true
     Dealroadshow\K8S\Framework\ResourceMaker\ConfigMapMaker: ~
     Dealroadshow\K8S\Framework\ResourceMaker\DeploymentMaker: ~
     Dealroadshow\K8S\Framework\ResourceMaker\SecretMaker: ~


### PR DESCRIPTION
This PR makes helpers (like `MetadataHelper` and `NamesHelper`) to be non-shared services in Symfony DI, in order to reduce the possibility of error